### PR TITLE
Add a way to inject variable content into PKI

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -366,3 +366,34 @@ pki_routes_default:
     realm: 'service/revoked'
     readlink: 'default.crl'
 
+
+# ---- Add external file contents from variables ----
+
+# This is a way to add contents of variables into the PKI directory structure
+# on remote hosts. You can use lists below to add certificates and keys from
+# Ansible Vault using variables. Specified paths are relative to
+# 'pki_base_path', by default "/etc/pki/".
+#
+# Files are added just after first Makefile run on remote hosts, and before CSR
+# files are sent to Ansible Controller.
+#
+# For example, a way to add a certificate and private key to PKI host realm
+# using variables:
+#
+# pki_inject_public_files:
+#   - path: 'host/certs/my.{{ ansible_domain }}.crt'
+#     content: '{{ vault_certitifate }}'
+#
+# pki_inject_private_files:
+#   - path: 'host/private/my.{{ ansible_domain }}.key'
+#     content: '{{ vault_private_key }}'
+#
+# If needed, you can specify 'item.{owner,group,mode}' dict keys, otherwise
+# default values will be used. 'item.path' and 'item.content' are required.
+
+# Add content of variables to public files
+pki_inject_public_files: []
+
+# Add content of variables to private files
+pki_inject_private_files: []
+

--- a/tasks/manage_pki_certificates.yml
+++ b/tasks/manage_pki_certificates.yml
@@ -21,6 +21,28 @@
   register: pki_register_make
   changed_when: pki_register_make.stdout is defined and pki_register_make.stdout
 
+- name: Inject external variables into specified public files
+  template:
+    src: 'etc/pki/variable-injector.j2'
+    dest: '{{ pki_base_path + "/" + item.path }}'
+    owner: '{{ item.owner | default(pki_owner) }}'
+    group: '{{ item.group | default(pki_public_group) }}'
+    mode: '{{ item.mode   | default(pki_public_mode) }}'
+  with_items: pki_inject_public_files
+  when: item.path is defined and item.path and
+        item.content is defined and item.content
+
+- name: Inject external variables into specified private files
+  template:
+    src: 'etc/pki/variable-injector.j2'
+    dest: '{{ pki_base_path + "/" + item.path }}'
+    owner: '{{ item.owner | default(pki_owner) }}'
+    group: '{{ item.group | default(pki_private_group) }}'
+    mode: '{{ item.mode   | default(pki_private_mode) }}'
+  with_items: pki_inject_private_files
+  when: item.path is defined and item.path and
+        item.content is defined and item.content
+
 - name: Upload Certificate Signing Requests
   fetch:
     src: '{{ pki_base_path + "/" + item.0.destination + "/requests/" + (item.1.filename | default(item.1.cn)) + ".csr" }}'

--- a/templates/etc/pki/variable-injector.j2
+++ b/templates/etc/pki/variable-injector.j2
@@ -1,0 +1,1 @@
+{{ item.content }}


### PR DESCRIPTION
You can use 'pki_inject_*_files' lists to add external variable content
into PKI directory structure.

Fixes #13