### PR TITLE
Update ca-certificates in Postfix chroot

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,7 +5,13 @@
 
 - name: Update ca-certificates.crt
   command: update-ca-certificates
+  notify: [ 'Install ca-certificates.crt into Postfix chroot' ]
 
 - name: Regenerate ca-certificates.crt
   command: update-ca-certificates --fresh
+  notify: [ 'Install ca-certificates.crt into Postfix chroot' ]
+
+- name: Install ca-certificates.crt into Postfix chroot
+  shell: test -d /var/spool/postfix &&
+         cp -f /etc/ssl/certs/ca-certificates.crt /var/spool/postfix/etc/ssl/certs/ca-certificates.crt || true
 


### PR DESCRIPTION
Postfix on Debian is run in a chrooted environment by default, and has
it's own copy of '/etc/ssl/certs/ca-certificates.crt' file which can
desynchronize after changes in CA certificate list. This change will
update it automatically if Postfix is installed.