### PR TITLE
The make.sh script should not fail silently.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ More information about `debops.pki` can be found in the
 
 - `debops.secret`
 
+This role runs some tasks on `localhost`. The machine running debops needs to have `make` and `openssl` available.
+
 ### Are you using this as a standalone role without DebOps?
 
 You may need to include missing roles from the [DebOps common

--- a/templates/secret/pki/make.sh.j2
+++ b/templates/secret/pki/make.sh.j2
@@ -1,6 +1,8 @@
 #!/bin/sh
 # This file is managed remotely, all changes will be lost
 
+set -e
+
 MAKE="make --silent --no-print-directory"
 
 ROOTCA="authorities/root"


### PR DESCRIPTION
The `make.sh` script should not fail silently if one of the make tasks fails. 
Also, it should probably be documented that `make` is required on the machine running _Debops_/_Ansible_.

Currently, if make is unavailable on `localhost` the script fails to generate all the proper certificates, but the `Execute source Makefiles` task returns `success`/`changed` and never warns that the certificates are missing or why they didn't successfully generate. I found this out the hard way when testing Debops under Cygwin on Windows.