### PR TITLE
Fixed ansible_managed because it is not default of the DebOps project.

### DIFF
--- a/templates/etc/ca-certificates.conf.j2
+++ b/templates/etc/ca-certificates.conf.j2
@@ -1,4 +1,4 @@
-# This file is managed remotely, some changes might be overwritten
+# {{ ansible_managed }}
 #
 # This file lists certificates that you wish to use or to ignore to be
 # installed in /etc/ssl/certs.

--- a/templates/etc/pki/Makefile.j2
+++ b/templates/etc/pki/Makefile.j2
@@ -1,4 +1,4 @@
-# This file is managed remotely, all changes will be lost
+# {{ ansible_managed }}
 
 PKI_BASE_PATH			= {{ pki_base_path      | default('/etc/pki') }}
 

--- a/templates/etc/pki/realm/Makefile.j2
+++ b/templates/etc/pki/realm/Makefile.j2
@@ -1,4 +1,4 @@
-# This file is managed remotely, all changes will be lost
+# {{ ansible_managed }}
 
 # PKI Makefile - client endpoint
 # Copyright (C) 2014 Maciej Delmanowski <drybjed@gmail.com>

--- a/templates/etc/pki/realm/templates/gnutls/default.cnf.j2
+++ b/templates/etc/pki/realm/templates/gnutls/default.cnf.j2
@@ -1,5 +1,5 @@
 {% set item = item.1 %}
-# This file is managed remotely, all changes will be lost
+# {{ ansible_managed }}
 
 # X.509 Certificate options
 #

--- a/templates/etc/pki/realm/templates/openssl/default.cnf.j2
+++ b/templates/etc/pki/realm/templates/openssl/default.cnf.j2
@@ -1,6 +1,6 @@
 {% set realm = item.0 %}
 {% set certificate = item.1 %}
-# This file is managed remotely, all changes will be lost
+# {{ ansible_managed }}
 
 HOME				= .
 RANDFILE			= $ENV::HOME/.rnd

--- a/templates/secret/pki/authorities/authority/Makefile.j2
+++ b/templates/secret/pki/authorities/authority/Makefile.j2
@@ -1,4 +1,4 @@
-# This file is managed remotely, all changes will be lost
+# {{ ansible_managed }}
 
 # ---- Ansible control variables ----
 

--- a/templates/secret/pki/authorities/authority/openssl.cnf.j2
+++ b/templates/secret/pki/authorities/authority/openssl.cnf.j2
@@ -1,5 +1,5 @@
 {% set authority = item %}
-# This file is managed remotely, all changes will be lost
+# {{ ansible_managed }}
 
 HOME				= ./.db
 RANDFILE			= $HOME/private/.random_seed

--- a/templates/secret/pki/make.sh.j2
+++ b/templates/secret/pki/make.sh.j2
@@ -1,5 +1,5 @@
 #!/bin/sh
-# This file is managed remotely, all changes will be lost
+# {{ ansible_managed }}
 
 set -e
 


### PR DESCRIPTION
* Would not be found by https://github.com/debops/debops/issues/120
* `git ls-files | xargs sed -i 's/\(This file is managed remotely, all changes will be lost\|This file is managed remotely, some changes might be overwritten\)/{{ ansible_managed }}/'`