### PR TITLE
Remove openssl-blacklist from packages

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
     install_recommends: False
   with_flattened:
     - [ 'ssl-cert', 'make', 'ca-certificates', 'gnutls-bin',
-         'openssl', 'openssl-blacklist', 'acl' ]
+         'openssl', 'acl' ]
     - pki_packages
 
 - name: Create base PKI directory


### PR DESCRIPTION
Not sure why I never stumbled on this issue before. I tried running the common playbook on a different hosting provider today and ran into a similar issue as [here](https://github.com/debops/ansible-apt/issues/31). Seems like `openssl-blacklist` isn't supported anymore so we should remove it from here as well.