### PR TITLE
Default value for ansible_all_ipv*_addresses

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -116,8 +116,8 @@ pki_vcs_ignore_patterns_host: []
 #
 # Enable or disable support for ACME certificates.
 pki_acme: '{{ (True
-               if ((ansible_all_ipv4_addresses +
-                    ansible_all_ipv6_addresses) | ipaddr("public") and
+               if ((ansible_all_ipv4_addresses|d([]) +
+                    ansible_all_ipv6_addresses|d([])) | ipaddr("public") and
                     pki_default_domain)
                else False) | bool }}'
 


### PR DESCRIPTION
Prevents error when `ansible_all_ipv4_addresses` is undefined