### PR TITLE
Ensure that /etc/pki directory exists

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -148,8 +148,13 @@
          (item.when|d(True) | bool))
 
 - name: Ensure that /etc/pki directory exists
-  file: path=/etc/pki state=directory
-
+  file:
+    path: /etc/pki
+    state: 'directory'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+    
 - name: Ensure that sensitive files are excluded from version control
   template:
     src: 'etc/pki/gitignore.j2'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -147,6 +147,9 @@
          (item.enabled|d(True) | bool) and
          (item.when|d(True) | bool))
 
+- name: Ensure that /etc/pki directory exists
+  file: path=/etc/pki state=directory
+
 - name: Ensure that sensitive files are excluded from version control
   template:
     src: 'etc/pki/gitignore.j2'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -149,7 +149,7 @@
 
 - name: Ensure that /etc/pki directory exists
   file:
-    path: /etc/pki
+    path: '/etc/pki'
     state: 'directory'
     owner: 'root'
     group: 'root'


### PR DESCRIPTION
received errors when running the example playbook from docs
/etc/pki directories did not exist on the hosts when the task to create the /etc/pki/.gitignore files