### PR TITLE
Change python print statements to functions

### DIFF
--- a/files/secret/pki/lib/pki-authority
+++ b/files/secret/pki/lib/pki-authority
@@ -54,12 +54,12 @@ array_exists () {
 
 # Get an absolute path to a file
 get_absolute_path () {
-    python -c 'import sys, os.path; print os.path.abspath(sys.argv[1])' "${1}"
+    python -c 'import sys, os.path; print(os.path.abspath(sys.argv[1]))' "${1}"
 }
 
 # Get a relative path to a file
 get_relative_path () {
-    python -c 'import sys, os.path; print os.path.relpath(sys.argv[1], sys.argv[2])' "${1}" "${2:-$PWD}"
+    python -c 'import sys, os.path; print(os.path.relpath(sys.argv[1], sys.argv[2]))' "${1}" "${2:-$PWD}"
 }
 
 # Wrap dnsdomainname if it's not present (on MacOS X)


### PR DESCRIPTION
This makes the scripts work well both under Python 2.x and 3.x