### PR TITLE
Don't run make any host modifications if pki is disabled

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -86,6 +86,7 @@
   become: False
   delegate_to: 'localhost'
   run_once: True
+  when: pki_enabled | bool
 
 - name: Install remote PKI scripts
   copy:
@@ -314,7 +315,8 @@
   run_once: True
   with_flattened:
     - '{{ pki_authorities + pki_dependent_authorities }}'
-  when: (item.name is defined and (item.enabled|d(True) | bool))
+  when: (pki_enabled|bool and item.name is defined and
+         (item.enabled|d(True) | bool))
 
 - name: Create PKI authorities
   environment:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -315,8 +315,7 @@
   run_once: True
   with_flattened:
     - '{{ pki_authorities + pki_dependent_authorities }}'
-  when: (pki_enabled|bool and item.name is defined and
-         (item.enabled|d(True) | bool))
+  when: (item.name is defined and (item.enabled|d(True) | bool))
 
 - name: Create PKI authorities
   environment:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -86,7 +86,7 @@
   become: False
   delegate_to: 'localhost'
   run_once: True
-  when: pki_enabled | bool
+  when: (pki_authorities or pki_dependent_authorities)
 
 - name: Install remote PKI scripts
   copy:


### PR DESCRIPTION
Alternatively, we could just move the entire `main.yml` to e.g. `pki.yml` and only include it, if `pki_enabled`. Then bugs like these wouldn't happen any more.

However, I wasn't fully sure, if there are no other roles depending on some tasks (facts?) if the role is not enabled.