### PR TITLE
[fix] pki-authority: Broken script when group contains spaces

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,6 +67,10 @@ Fixed
 
 - Reviewed the role. Fixed potential shell script issues reported by
   :command:`shellcheck` and added CI tests using :command:`shellcheck`. [ypid_]
+  
+- Use the group id instead of group names (`id -gn` -> `id -g`) in
+  :program:`pki-realm` and :program:`pki-authority` to cope with group names with
+  spaces which can happen when LDAP is used. [zpfvo_]
 
 
 `debops.pki v0.2.13`_ - 2016-07-07

--- a/files/secret/pki/lib/pki-authority
+++ b/files/secret/pki/lib/pki-authority
@@ -137,11 +137,11 @@ initialize_environment () {
     config["cert_sign_days"]=""
     config["key_size"]="4096"
 
-    config["public_dir_group"]="$(id -gn)"
-    config["public_file_group"]="$(id -gn)"
+    config["public_dir_group"]="$(id -g)"
+    config["public_file_group"]="$(id -g)"
 
-    config["private_dir_group"]="$(id -gn)"
-    config["private_file_group"]="$(id -gn)"
+    config["private_dir_group"]="$(id -g)"
+    config["private_file_group"]="$(id -g)"
 
     config["public_dir_mode"]="755"
     config["private_dir_mode"]="700"

--- a/files/usr/local/lib/pki/pki-realm
+++ b/files/usr/local/lib/pki/pki-realm
@@ -266,17 +266,17 @@ initialize_environment () {
         config["pki_realms"]="${config['pki_root']}/realms"
         config["pki_hooks"]="${config['pki_root']}/hooks"
 
-        config["public_dir_group"]="$(id -gn)"
-        config["public_file_group"]="$(id -gn)"
+        config["public_dir_group"]="$(id -g)"
+        config["public_file_group"]="$(id -g)"
 
-        config["private_dir_group"]="$(id -gn)"
-        config["private_file_group"]="$(id -gn)"
+        config["private_dir_group"]="$(id -g)"
+        config["private_file_group"]="$(id -g)"
 
-        config["realm_dir_group"]="$(id -gn)"
-        config["realm_file_group"]="$(id -gn)"
+        config["realm_dir_group"]="$(id -g)"
+        config["realm_file_group"]="$(id -g)"
 
-        config["acme_dir_group"]="$(id -gn)"
-        config["acme_file_group"]="$(id -gn)"
+        config["acme_dir_group"]="$(id -g)"
+        config["acme_file_group"]="$(id -g)"
 
         config["public_dir_mode"]="755"
         config["acme_dir_mode"]="775"


### PR DESCRIPTION
When $(id -gn) returns a group name with spaces the script fails. 
Without -n the id is used and there are no problems.