### PR TITLE
Added pre- and post-hooks to PKI role

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,9 @@
 ---
 # .. vim: foldmarker=[[[,]]]:foldmethod=marker
 
+- name: DebOps pre_tasks hook
+  include: "{{ lookup('task_src', 'pki/pre_main.yml') }}"
+
 - name: Generate random session token
   set_fact:
     pki_fact_session_token: '{{ 9999999999999999999999999999999999999 | random | string | hash("sha256") }}'
@@ -508,4 +511,8 @@
 - name: Flush handlers for PKI if needed
   meta: flush_handlers
   when: pki_register_facts|changed
+
+- name: DebOps post_tasks hook
+  include: "{{ lookup('task_src', 'pki/post_main.yml') }}"
+
 # ]]]

--- a/tasks/pki/post_main.yml
+++ b/tasks/pki/post_main.yml
@@ -1,0 +1,8 @@
+# You can have your own tasks run before and after the pki role
+# by creating a tasks/pki/pre_main.yml relative to your playbook.
+# To make debops find these, place something like following in
+# your .debops.cfg:
+#   [paths]
+#   template-paths: ansible/templates
+#   task-paths: ansible/tasks/
+#   file-paths: ansible/files/

--- a/tasks/pki/pre_main.yml
+++ b/tasks/pki/pre_main.yml
@@ -1,0 +1,8 @@
+# You can have your own tasks run before and after the pki role
+# by creating a tasks/pki/pre_main.yml relative to your playbook.
+# To make debops find these, place something like following in
+# your .debops.cfg:
+#   [paths]
+#   template-paths: ansible/templates
+#   task-paths: ansible/tasks/
+#   file-paths: ansible/files/


### PR DESCRIPTION
This makes it easier to customise the behaviour of the role.  In my case, I intend to configure the necessary directories (think challenge-web-root) before the pki role runs.  Other roles use the same pattern (well, dovecot at least), so I thought it would be appropriate for the PKI role to do the same.