### PR TITLE
Ensure host's output certificate directory exists

### DIFF
--- a/files/secret/pki/lib/pki-authority
+++ b/files/secret/pki/lib/pki-authority
@@ -740,6 +740,7 @@ sign_openssl_host_certificate () {
 
         if [ -r "${sign_request}" ] && [ ! -r "${sign_out}" ] ; then
 
+	    mkdir -p "$(dirname ${sign_out})"
             _openssl ca -batch -notext \
                 -in "${sign_request}" -out "${sign_out}.tmp" \
                 -config "${sign_config}"


### PR DESCRIPTION
openssl was failing because of this directory not existing.
