### PR TITLE
always_run is deprecated. Use check_mode = no instead..

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,11 @@ The current role maintainer_ is drybjed_.
 
 .. _debops.pki master: https://github.com/debops/ansible-pki/compare/v0.2.14...master
 
+Fixed
+~~~~~
+
+- Fix Ansible 2.2 deprecation warnings. [brzhk]
+
 Added
 ~~~~~
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,8 @@ The current role maintainer_ is drybjed_.
 Fixed
 ~~~~~
 
-- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher.
+  Support for older Ansible versions is dropped. [brzhk]
 
 Added
 ~~~~~

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,7 @@ The current role maintainer_ is drybjed_.
 Fixed
 ~~~~~
 
-- Fix Ansible 2.2 deprecation warnings. [brzhk]
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]
 
 Added
 ~~~~~

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,7 +10,7 @@ galaxy_info:
   author: 'Maciej Delmanowski'
   description: 'Bootstrap and manage internal PKI, Certificate Authorities and OpenSSL/GnuTLS certificates'
   license: 'GPL-3.0'
-  min_ansible_version: '2.0.0'
+  min_ansible_version: '2.2.0'
 
   platforms:
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,7 +44,7 @@
   delegate_to: 'localhost'
   become: False
   run_once: True
-  always_run: True
+  check_mode: no
 
 - name: Check Ansible Controller crypto library version
   shell: |
@@ -58,7 +58,7 @@
   delegate_to: 'localhost'
   become: False
   run_once: True
-  always_run: True
+  check_mode: no
 
 - name: Assert that required dependencies are met as documented
   assert:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,7 +44,7 @@
   delegate_to: 'localhost'
   become: False
   run_once: True
-  check_mode: no
+  check_mode: False
 
 - name: Check Ansible Controller crypto library version
   shell: |
@@ -58,7 +58,7 @@
   delegate_to: 'localhost'
   become: False
   run_once: True
-  check_mode: no
+  check_mode: False
 
 - name: Assert that required dependencies are met as documented
   assert:


### PR DESCRIPTION
[DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead..
This feature will be removed in version 2.4. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.