### PR TITLE
Assert bash version using environment

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,9 +36,7 @@
 
 # Assert that required dependencies are met as documented [[[
 - name: Check Ansible Controller bash version
-  shell: echo $BASH_VERSION
-  args:
-    executable: '/bin/bash'
+  command: "/usr/bin/env bash -c 'echo $BASH_VERSION'"
   changed_when: False
   register: pki__register_bash_version
   delegate_to: 'localhost'


### PR DESCRIPTION
I observed that the assertion in the `ansible-pki` role that check the bash version use an hardcoded path (`/bin/bash`) rather than looking in `$PATH`.

I use Mac OS X and installed bash using Homebrew, so I use `export PATH=/usr/local/bin:$PATH` in order to use DebOps and this needs this commit to work.

Thanks for your time,