### PR TITLE
114 evilham name constraints docs visibility

### DIFF
--- a/docs/defaults-detailed.rst
+++ b/docs/defaults-detailed.rst
@@ -231,6 +231,8 @@ respectively:
            - 'dns:*.{{ ansible_domain }}'
            - 'dns:{{ ansible_domain }}'
 
+.. _pki__ref_authorities:
+
 pki_authorities
 ---------------
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -70,7 +70,7 @@ ones you will likely want to change are:
   This is the list of internal Certificate Authorities managed on an Ansible
   Controller.
 
-  ``debops-pki`` now supports the X.509 Name Constraints certificate extension by
+  ``debops.pki`` now supports the X.509 Name Constraints certificate extension by
   default. This may break software using old version of OpenSSL and multi-domain
   environments. Please see ``name_constraints`` under :ref:`pki__ref_authorities`
   for more information.

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -72,7 +72,7 @@ ones you will likely want to change are:
 
   ``debops-pki`` now supports the X.509 Name Constraints certificate extension by
   default. This may break software using old version of OpenSSL and multi-domain
-  environments. Please see ``name_constraints``under :ref:`pki__ref_authorities`
+  environments. Please see ``name_constraints`` under :ref:`pki__ref_authorities`
   for more information.
 
 Example inventory

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -66,6 +66,15 @@ ones you will likely want to change are:
   Certificate Authority and Domain Certificate Authority. The value is a list
   of DN entries which define the subject.
 
+:envvar:`pki_authorities`
+  This is the list of internal Certificate Authorities managed on an Ansible
+  Controller.
+
+  ``debops-pki`` now supports the X.509 Name Constraints certificate extension by
+  default. This may break software using old version of OpenSSL and multi-domain
+  environments. Please see ``name_constraints``under :ref:`pki__ref_authorities`
+  for more information.
+
 Example inventory
 -----------------
 


### PR DESCRIPTION
Fix for #114, calling attention to `pki_authorities` and `name_constraints` on the getting-started page.